### PR TITLE
Make includes more consistent, use the gcc_7x to_string function

### DIFF
--- a/include/contracts_lite/enforcement.hpp
+++ b/include/contracts_lite/enforcement.hpp
@@ -22,6 +22,7 @@
 #ifndef CONTRACTS__ENFORCEMENT_HPP_
 #define CONTRACTS__ENFORCEMENT_HPP_
 
+#include <cstdint>
 #include <string>
 #include <utility>
 

--- a/include/contracts_lite/range_checks.hpp
+++ b/include/contracts_lite/range_checks.hpp
@@ -15,8 +15,6 @@
 #ifndef CONTRACTS__RANGE_CHECKS_HPP_
 #define CONTRACTS__RANGE_CHECKS_HPP_
 
-#include <string>
-
 #include "contracts_lite/contract_types.hpp"
 
 namespace contracts_lite {
@@ -31,8 +29,9 @@ template <typename T, typename U>
 ReturnStatus in_range_open_open(const T& value, const U& min, const U& max) {
   const auto inside_min = (static_cast<U>(value) > min);
   const auto inside_max = (static_cast<U>(value) < max);
-  const auto comment = std::to_string(value) + " must be inside the range (" +
-                       std::to_string(min) + ", " + std::to_string(max) + ")";
+  const auto comment =
+      gcc_7x_to_string_fix(value) + " must be inside the range (" +
+      gcc_7x_to_string_fix(min) + ", " + gcc_7x_to_string_fix(max) + ")";
   return ReturnStatus(comment, inside_min && inside_max);
 }
 
@@ -45,8 +44,9 @@ template <typename T, typename U>
 ReturnStatus in_range_closed_open(const T& value, const U& min, const U& max) {
   const auto inside_min = (static_cast<U>(value) >= min);
   const auto inside_max = (static_cast<U>(value) < max);
-  const auto comment = std::to_string(value) + " must be inside the range [" +
-                       std::to_string(min) + ", " + std::to_string(max) + ")";
+  const auto comment =
+      gcc_7x_to_string_fix(value) + " must be inside the range [" +
+      gcc_7x_to_string_fix(min) + ", " + gcc_7x_to_string_fix(max) + ")";
   return ReturnStatus(comment, inside_min && inside_max);
 }
 
@@ -59,8 +59,9 @@ template <typename T, typename U>
 ReturnStatus in_range_open_closed(const T& value, const U& min, const U& max) {
   const auto inside_min = (static_cast<U>(value) > min);
   const auto inside_max = (static_cast<U>(value) <= max);
-  const auto comment = std::to_string(value) + " must be inside the range (" +
-                       std::to_string(min) + ", " + std::to_string(max) + "]";
+  const auto comment =
+      gcc_7x_to_string_fix(value) + " must be inside the range (" +
+      gcc_7x_to_string_fix(min) + ", " + gcc_7x_to_string_fix(max) + "]";
   return ReturnStatus(comment, inside_min && inside_max);
 }
 
@@ -74,8 +75,9 @@ ReturnStatus in_range_closed_closed(const T& value, const U& min,
                                     const U& max) {
   const auto inside_min = (static_cast<U>(value) >= min);
   const auto inside_max = (static_cast<U>(value) <= max);
-  const auto comment = std::to_string(value) + " must be inside the range [" +
-                       std::to_string(min) + ", " + std::to_string(max) + "]";
+  const auto comment =
+      gcc_7x_to_string_fix(value) + " must be inside the range [" +
+      gcc_7x_to_string_fix(min) + ", " + gcc_7x_to_string_fix(max) + "]";
   return ReturnStatus(comment, inside_min && inside_max);
 }
 

--- a/include/contracts_lite/simple_violation_handler.hpp
+++ b/include/contracts_lite/simple_violation_handler.hpp
@@ -47,10 +47,10 @@ inline void handler_without_continuation(
 /** @brief Define the build-dependent contract violation handler. */
 #ifdef CONTRACT_VIOLATION_CONTINUATION_MODE_ON
 #define CONTRACT_VIOLATION_HANDLER(violation) \
-  contracts_lite::handler_with_continuation(violation)
+  ::contracts_lite::handler_with_continuation(violation)
 #else
 #define CONTRACT_VIOLATION_HANDLER(violation) \
-  contracts_lite::handler_without_continuation(violation)
+  ::contracts_lite::handler_without_continuation(violation)
 #endif
 
 #include "contracts_lite/enforcement.hpp"

--- a/include/contracts_lite/simple_violation_handler.hpp
+++ b/include/contracts_lite/simple_violation_handler.hpp
@@ -15,10 +15,10 @@
 #ifndef CONTRACTS__SIMPLE_VIOLATION_HANDLER_HPP_
 #define CONTRACTS__SIMPLE_VIOLATION_HANDLER_HPP_
 
-#include <cstdint>
+#include <exception>
 #include <iostream>
+#include <stdexcept>
 #include <string>
-#include <utility>
 
 #include "contracts_lite/contract_types.hpp"
 


### PR DESCRIPTION
This diff does two things:

1. Make includes more consistent: some files had unnecessary includes, or were using things they did not include explicitly
1. The range checks were using `std::to_string` instead of `gcc_7x_to_string_fix`; the `gcc_*` function is necessary for Autoware compatibility.