### PR TITLE
Enforce that audit macros assume ownership of ReturnStatus

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ Two enforcement macros are provided to allow enforcement at the 'default' and 'a
 - `DEFAULT_ENFORCE(ReturnStatus)`: invokes violation handler if ReturnStatus arg is `false`
 - `AUDIT_ENFORCE(ReturnStatus)`: invokes violation handler if ReturnStatus arg is `false`
 
+> NOTE: The macros should be treated as if they assume ownership of The `ReturnStatus` argument. For this reason, the argument needs to be either an rvalue or a non-const lvalue.
+
 When writing functions that check contract conditions, the comment field of the ReturnStatus object can be used to describe the specific conditions of failure (e.g. what value resulted in a failed check).
 It is often desirable to make these comments informative by adding specific run time information to them.
 Doing this, however, can be computationally expensive, which may be unacceptable for default-enforced contracts under default enforcement, but acceptable for default-enforced contracts under audit enforcement.

--- a/include/contracts_lite/contract_types.hpp
+++ b/include/contracts_lite/contract_types.hpp
@@ -69,6 +69,13 @@ std::string gcc_7x_to_string_fix(const T& val) {
 struct ReturnStatus {
   ReturnStatus(std::string comment, bool status)
       : comment(std::move(comment)), status(status) {}
+  ReturnStatus(ReturnStatus& rs)
+      : ReturnStatus(std::move(rs.comment), rs.status) {}
+  ReturnStatus(ReturnStatus&& rs)
+      : ReturnStatus(std::move(rs.comment), rs.status) {}
+
+  /** @brief Disallow default construction. */
+  ReturnStatus() = delete;
 
   /** @brief Allow objects to be directly cast to bool types. */
   operator bool() const { return status; }

--- a/include/contracts_lite/enforcement.hpp
+++ b/include/contracts_lite/enforcement.hpp
@@ -68,13 +68,13 @@
  * @brief Invokes violation handler if contract_check arg evaluates to `true`
  * @note INTERNAL USE ONLY
  */
-#define ENFORCE_CONTRACT(contract_check)                 \
-  {                                                      \
-    auto check = std::move(contract_check);              \
-    if (!check.status) {                                 \
-      CONTRACT_VIOLATION_HANDLER(                        \
-          CONTRACT_VIOLATION(std::move(check.comment))); \
-    }                                                    \
+#define ENFORCE_CONTRACT(contract_check)                   \
+  {                                                        \
+    ::contracts_lite::ReturnStatus check = contract_check; \
+    if (!check.status) {                                   \
+      CONTRACT_VIOLATION_HANDLER(                          \
+          CONTRACT_VIOLATION(std::move(check.comment)));   \
+    }                                                      \
   }
 
 /** @brief enforcement Macros that enforce contracts based on build level. */


### PR DESCRIPTION
The current audit macros move the return status argument to a local variable for processing. This assumes that the macro code takes ownership of the argument, but the code wasn't enforcing this behavior. This change enforces that behavior, which can help prevent inadvertent copies from being made, and also avoids a `moving a temporary object prevents copy elision` warning when giving the macros an rvalue.