### PR TITLE
try to fix gtest build

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -23,7 +23,7 @@ jobs:
         cd /usr/src/gtest
         sudo cmake .
         sudo make
-        sudo cp *.a /usr/lib
+        sudo cp lib/*.a /usr/lib
 
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
Getting error during the install gtest step:

```
cp: cannot stat '*.a': No such file or directory
```

It appears libraries are built into a `lib/` sub-directory; maybe this fixes the copy error.